### PR TITLE
Api token auth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Ivan Bojer <ibojer@paloaltonetworks.com>
 Luigi Mori <lmori@paloaltonetworks.com>
+John Anderson <lampwins@gmail.com>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Overview of modules
 
 - panos_admin - add or modify admin user
 - panos_admpwd - set admin password via SSH
+- panos_apikey - generate a new api key
 - panos_awsmonitor - create AWS VM monitor
 - panos_cert_gen_ssh - create SSL certificate
 - panos_check - check if device is ready

--- a/library/panos_admin
+++ b/library/panos_admin
@@ -149,6 +149,7 @@ def admin_set(xapi, module, admin_username, admin_password, role):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         admin_username=dict(default='admin'),
@@ -162,14 +163,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     admin_username = module.params['admin_username']

--- a/library/panos_admin
+++ b/library/panos_admin
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_apikey.py
+++ b/library/panos_apikey.py
@@ -43,7 +43,7 @@ options:
         description:
             - timeout of API calls
         required: false
-        default: "0"
+        default: "60"
 '''
 
 EXAMPLES = '''
@@ -68,7 +68,7 @@ def main():
         ip_address=dict(default=None),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
-        timeout=dict(default=0, type='int')
+        timeout=dict(default=60, type='int')
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/library/panos_apikey.py
+++ b/library/panos_apikey.py
@@ -88,11 +88,12 @@ def main():
         timeout=timeout
     )
 
-    try:
-        key = xapi.keygen()
-        module.exit_json(changed=True, msg=key)
-    except:
-        module.fail_json(msg="Failed")
+    key = xapi.keygen()
+    if not key:
+        module.fail_json(msg="failed")
+    else:
+        module.exit_json(changed=True, key=key)
+
 
 from ansible.module_utils.basic import *   # noqa
 

--- a/library/panos_apikey.py
+++ b/library/panos_apikey.py
@@ -92,9 +92,7 @@ def main():
         key = xapi.keygen()
         module.exit_json(changed=True, msg=key)
     except:
-        pass
-
-    module.fail_json(msg="Failed")
+        module.fail_json(msg="Failed")
 
 from ansible.module_utils.basic import *   # noqa
 

--- a/library/panos_apikey.py
+++ b/library/panos_apikey.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2014, Palo Alto Networks <techbizdev@paloaltonetworks.com>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+DOCUMENTATION = '''
+---
+module: panos_apikey
+short_description: generate an api key
+description:
+    - Use the XML API to generate a new API Key for later use
+author:
+    - John Anderson
+version_added: "0.0"
+requirements:
+    - pan-python
+options:
+    ip_address:
+        description:
+            - IP address (or hostname) of PAN-OS device
+        required: true
+    password:
+        description:
+            - password for authentication
+        required: true
+    username:
+        description:
+            - username for authentication
+        required: false
+        default: "admin"
+    timeout:
+        description:
+            - timeout of API calls
+        required: false
+        default: "0"
+'''
+
+EXAMPLES = '''
+# 192.168.1.1 with credentials admin/admin
+- name: generate key
+  panos_apikey:
+    ip_address: "192.168.1.1"
+    password: "admin"
+'''
+
+import sys
+
+try:
+    import pan.xapi
+except ImportError:
+    print "failed=True msg='pan-python required for this module'"
+    sys.exit(1)
+
+
+def main():
+    argument_spec = dict(
+        ip_address=dict(default=None),
+        password=dict(default=None, no_log=True),
+        username=dict(default='admin'),
+        timeout=dict(default=0, type='int')
+    )
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    ip_address = module.params["ip_address"]
+    if not ip_address:
+        module.fail_json(msg="ip_address should be specified")
+    password = module.params["password"]
+    if not password:
+        module.fail_json(msg="password is required")
+    username = module.params['username']
+    timeout = module.params['timeout']
+
+    xapi = pan.xapi.PanXapi(
+        hostname=ip_address,
+        api_username=username,
+        api_password=password,
+        timeout=timeout
+    )
+
+    try:
+        key = xapi.keygen()
+        module.exit_json(changed=True, msg=key)
+    except:
+        pass
+
+    module.fail_json(msg="Failed")
+
+from ansible.module_utils.basic import *   # noqa
+
+main()

--- a/library/panos_awsmonitor
+++ b/library/panos_awsmonitor
@@ -29,10 +29,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_awsmonitor
+++ b/library/panos_awsmonitor
@@ -128,6 +128,7 @@ def add_awsmonitor(xapi, monitor_name, vpc_id, source,
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         monitor_name=dict(default=None),
@@ -143,14 +144,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     monitor_name = module.params['monitor_name']

--- a/library/panos_check
+++ b/library/panos_check
@@ -112,8 +112,8 @@ def main():
     ip_address = module.params["ip_address"]
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
-    key = module.params["key"]
     password = module.params["password"]
+    key = module.params["key"]
     if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']

--- a/library/panos_check
+++ b/library/panos_check
@@ -136,7 +136,7 @@ def main():
         )
 
     xapi = pan.xapi.PanXapi(
-        args
+        **args
     )
 
     checkpnt = time.time()+timeout

--- a/library/panos_check
+++ b/library/panos_check
@@ -32,10 +32,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication
@@ -97,6 +101,7 @@ def check_jobs(jobs, module):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         timeout=dict(default=0, type='int'),
@@ -107,18 +112,30 @@ def main():
     ip_address = module.params["ip_address"]
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
+    key = module.params["key"]
     password = module.params["password"]
-    if not password:
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
     timeout = module.params['timeout']
     interval = module.params['interval']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password,
-        timeout=60
+        args
     )
 
     checkpnt = time.time()+timeout

--- a/library/panos_check
+++ b/library/panos_check
@@ -131,6 +131,7 @@ def main():
         args = dict(
             hostname=ip_address,
             api_key=key,
+            api_username=username,
             timeout=60
         )
 

--- a/library/panos_commit
+++ b/library/panos_commit
@@ -81,6 +81,7 @@ except ImportError:
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         interval=dict(default=0.5),
@@ -93,7 +94,8 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
@@ -101,10 +103,23 @@ def main():
     timeout = module.params['timeout']
     sync = module.params['sync']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     xapi.commit(

--- a/library/panos_commit
+++ b/library/panos_commit
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_content
+++ b/library/panos_content
@@ -233,6 +233,7 @@ def download_url_region(xapi, module, region, job_timeout):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         url_download_region=dict(default=None),
@@ -247,16 +248,30 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
     job_timeout = module.params['job_timeout']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     changed = False

--- a/library/panos_content
+++ b/library/panos_content
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_cstapphost
+++ b/library/panos_cstapphost
@@ -147,6 +147,7 @@ def convert_to_regex(hname):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         app_name=dict(default=None),
@@ -160,14 +161,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     app_name = module.params['app_name']

--- a/library/panos_cstapphost
+++ b/library/panos_cstapphost
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_dag
+++ b/library/panos_dag
@@ -32,11 +32,14 @@ options:
             - IP address (or hostname) of PAN-OS device
         required: true
         default: null
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
-        default: null
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_dag
+++ b/library/panos_dag
@@ -111,7 +111,8 @@ def add_dag(xapi, dag_name, dag_filter):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
-        password=dict(default=None),
+        key=dict(default=None, no_log=True),
+        password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         dag_name=dict(default=None),
         dag_filter=dict(default=None),
@@ -127,10 +128,23 @@ def main():
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     dag_name = module.params['dag_name']

--- a/library/panos_dhcpif
+++ b/library/panos_dhcpif
@@ -129,6 +129,7 @@ def if_exists(xapi, if_name):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         if_name=dict(default=None),
@@ -142,14 +143,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     if_name = module.params['if_name']

--- a/library/panos_dhcpif
+++ b/library/panos_dhcpif
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_dnat
+++ b/library/panos_dnat
@@ -171,6 +171,7 @@ def add_dnat(xapi, module, rule_name, from_zone, to_zone,
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         rule_name=dict(default=None),
@@ -189,14 +190,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     rule_name = module.params['rule_name']

--- a/library/panos_dnat
+++ b/library/panos_dnat
@@ -33,10 +33,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_gpp_gateway
+++ b/library/panos_gpp_gateway
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_gpp_gateway
+++ b/library/panos_gpp_gateway
@@ -230,6 +230,7 @@ def check_gpp_gateway(xapi, module, portal_name, config_name, gateway_address,
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         portal_name=dict(default=None),
@@ -247,14 +248,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     portal_name = module.params['portal_name']

--- a/library/panos_import
+++ b/library/panos_import
@@ -151,6 +151,7 @@ def delete_file(path):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         category=dict(default='software'),
@@ -163,14 +164,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     file_ = module.params['file']

--- a/library/panos_import
+++ b/library/panos_import
@@ -33,10 +33,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_lic
+++ b/library/panos_lic
@@ -122,6 +122,7 @@ def fetch_authcode(xapi, module):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         auth_code=dict(default=None),
         username=dict(default='admin'),
@@ -133,16 +134,30 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     auth_code = module.params["auth_code"]
     force = module.params['force']
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     if not force:

--- a/library/panos_lic
+++ b/library/panos_lic
@@ -33,10 +33,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_loadcfg
+++ b/library/panos_loadcfg
@@ -94,6 +94,7 @@ def load_cfgfile(xapi, module, ip_address, file_):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         file=dict(default=None),
@@ -105,14 +106,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     file_ = module.params['file']

--- a/library/panos_loadcfg
+++ b/library/panos_loadcfg
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_mgtconfig
+++ b/library/panos_mgtconfig
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_mgtconfig
+++ b/library/panos_mgtconfig
@@ -146,6 +146,7 @@ def set_panorama_server(xapi, new_panorama_server, primary=True):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         dns_server_primary=dict(default=None),
@@ -160,14 +161,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     dns_server_primary = module.params['dns_server_primary']

--- a/library/panos_nat
+++ b/library/panos_nat
@@ -251,6 +251,7 @@ def add_nat(xapi, module, rule_name, from_zone, to_zone,
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         rule_name=dict(default=None),
@@ -275,14 +276,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     rule_name = module.params['rule_name']

--- a/library/panos_nat
+++ b/library/panos_nat
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_pg
+++ b/library/panos_pg
@@ -153,6 +153,7 @@ def add_pg(xapi, pg_name, data_filtering, file_blocking, spyware,
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         pg_name=dict(default=None),
@@ -170,14 +171,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     pg_name = module.params['pg_name']

--- a/library/panos_pg
+++ b/library/panos_pg
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_restart
+++ b/library/panos_restart
@@ -29,10 +29,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_restart
+++ b/library/panos_restart
@@ -63,6 +63,7 @@ except ImportError:
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin')
     )
@@ -72,14 +73,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     try:

--- a/library/panos_service
+++ b/library/panos_service
@@ -122,6 +122,7 @@ def add_service(xapi, module, service_name, protocol, port, source_port):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         service_name=dict(default=None),
@@ -136,14 +137,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     service_name = module.params['service_name']

--- a/library/panos_service
+++ b/library/panos_service
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_snat
+++ b/library/panos_snat
@@ -245,6 +245,7 @@ def add_snat_dipp(xapi, module, rule_name, from_zone, to_zone,
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         rule_name=dict(default=None),
@@ -267,14 +268,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     rule_name = module.params['rule_name']

--- a/library/panos_snat
+++ b/library/panos_snat
@@ -34,10 +34,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_srule
+++ b/library/panos_srule
@@ -30,10 +30,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_srule
+++ b/library/panos_srule
@@ -260,6 +260,7 @@ def add_security_rule(xapi, **kwargs):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         rule_name=dict(default=None),
@@ -286,14 +287,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     rule_name = module.params['rule_name']

--- a/library/panos_sshkey
+++ b/library/panos_sshkey
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_sshkey
+++ b/library/panos_sshkey
@@ -112,6 +112,7 @@ def set_publickey(xapi, user, cpkey, pkey):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         admin_username=dict(default=None, required=True),
@@ -126,14 +127,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     panos_user = module.params['admin_username']

--- a/library/panos_swapif
+++ b/library/panos_swapif
@@ -30,11 +30,14 @@ options:
             - IP address (or hostname) of PAN-OS device
         required: true
         default: null
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
-        default: null
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_swapif
+++ b/library/panos_swapif
@@ -70,7 +70,8 @@ except ImportError:
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
-        password=dict(default=None),
+        key=dict(default=None, no_log=True),
+        password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         swap=dict(default='no')
     )
@@ -80,15 +81,29 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
     swap = module.params['swap']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     try:

--- a/library/panos_swinstall
+++ b/library/panos_swinstall
@@ -32,10 +32,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_swinstall
+++ b/library/panos_swinstall
@@ -139,6 +139,7 @@ def install_software(xapi, module, version, file_, job_timeout):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         version=dict(default=None),
@@ -151,14 +152,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     job_timeout = module.params['job_timeout']

--- a/library/panos_tunnelif
+++ b/library/panos_tunnelif
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_tunnelif
+++ b/library/panos_tunnelif
@@ -114,6 +114,7 @@ def if_exists(xapi, tunnel_unit):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         tunnel_unit=dict(default=None),
@@ -126,14 +127,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     tunnel_unit = module.params['tunnel_unit']

--- a/library/panos_vulnprofile
+++ b/library/panos_vulnprofile
@@ -31,10 +31,14 @@ options:
         description:
             - IP address (or hostname) of PAN-OS device
         required: true
+    key:
+        description:
+            - api key for authentication used in place of username and password
+        required: false
     password:
         description:
             - password for authentication
-        required: true
+        required: false
     username:
         description:
             - username for authentication

--- a/library/panos_vulnprofile
+++ b/library/panos_vulnprofile
@@ -174,6 +174,7 @@ def add_vulnerability_profile(xapi, **kwargs):
 def main():
     argument_spec = dict(
         ip_address=dict(default=None),
+        key=dict(default=None, no_log=True),
         password=dict(default=None, no_log=True),
         username=dict(default='admin'),
         vulnprofile_name=dict(default=None),
@@ -188,14 +189,28 @@ def main():
     if not ip_address:
         module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
+    key = module.params["key"]
+    if not password and not key:
         module.fail_json(msg="password is required")
     username = module.params['username']
 
+    if not key:
+        args = dict(
+            hostname=ip_address,
+            api_username=username,
+            api_password=password,
+            timeout=60
+        )
+    else:
+        args = dict(
+            hostname=ip_address,
+            api_key=key,
+            api_username=username,
+            timeout=60
+        )
+
     xapi = pan.xapi.PanXapi(
-        hostname=ip_address,
-        api_username=username,
-        api_password=password
+        **args
     )
 
     vulnprofile_name = module.params["vulnprofile_name"]


### PR DESCRIPTION
Added support for using an API key in place of username/password in all places where the `xapi` is used.  Also added a new module `panos_apikey` which is used to grant and new key.