### PR TITLE
missed import AnsibleModule

### DIFF
--- a/library/panos_nat_rule.py
+++ b/library/panos_nat_rule.py
@@ -154,7 +154,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 
-from ansible.module_utils.basic import get_exception
+from ansible.module_utils.basic import get_exception, AnsibleModule
 
 try:
     import pan.xapi


### PR DESCRIPTION
```
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/h3/drvf3vqj4q771900brh_sfwr0dq3dr/T/ansible_HEKLLw/ansible_module_panos_nat_rule.py", line 467, in <module>
    main()
  File "/var/folders/h3/drvf3vqj4q771900brh_sfwr0dq3dr/T/ansible_HEKLLw/ansible_module_panos_nat_rule.py", line 312, in main
    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,
NameError: global name 'AnsibleModule' is not defined
```

added the import. to panos_nat_rule. Only one that I tested 