### PR TITLE
Fixed examples

### DIFF
--- a/docs/modules/panos_op_module.rst
+++ b/docs/modules/panos_op_module.rst
@@ -74,14 +74,14 @@ Examples
  ::
 
     - name: show list of all interfaces
-      panos_object:
+      panos_op:
         ip_address: '{{ ip_address }}'
         username: '{{ username }}'
         password: '{{ password }}'
         cmd: 'show interfaces all'
     
     - name: show system info
-      panos_object:
+      panos_op:
         ip_address: '{{ ip_address }}'
         username: '{{ username }}'
         password: '{{ password }}'


### PR DESCRIPTION
They used panos_object instead of panos_op