### PR TITLE
Typo in mgtconfig

### DIFF
--- a/library/panos_mgtconfig.py
+++ b/library/panos_mgtconfig.py
@@ -185,7 +185,7 @@ def main():
     login_banner = module.params['login_banner']
     update_server = module.params['update_server']
     hostname = module.params['hostname']
-    domain = module.params['hostname']
+    domain = module.params['domain']
     devicegroup = module.params['devicegroup']
 
     # Create the device with the appropriate pandevice type


### PR DESCRIPTION
Fixing a typo that causes the hostname var to apply to the domain name