### PR TITLE
Allow Interface to be declared on Static Route

### DIFF
--- a/library/panos_static_route.py
+++ b/library/panos_static_route.py
@@ -75,7 +75,7 @@ options:
         default: 'default'
     interface:
         description:
-            - The interface to use.
+            - The Interface to use.
     state:
         description:
             - Create or remove static route.


### PR DESCRIPTION
We had an issue committing Static Routes without having the Interface specified. This PR exposes the Interface property from the underlying pandevice module.