### PR TITLE
Allow nexthop type of None in panos_static_route module

### DIFF
--- a/docs/modules/panos_static_route_module.md
+++ b/docs/modules/panos_static_route_module.md
@@ -27,7 +27,7 @@ Create static routes on PAN-OS devices.
 | metric |  | 10 |  | Metric for route. |
 | name | yes |  |  | Name of static route. |
 | nexthop |  |  |  | Next hop IP address.  Required if *state* is *present*. |
-| nexthop_type |  | ip-address | ip-address, discard, null | Type of next hop. |
+| nexthop_type |  | ip-address | ip-address, discard, none | Type of next hop. |
 | password |  |  |  | Password for authentication for PAN-OS device.  Optional if *api_key* is used. |
 | state |  | present | present, absent | Create or remove static route. |
 | username |  | admin |  | Username for authentication for PAN-OS device.  Optional if *api_key* is used. |
@@ -43,7 +43,7 @@ Create static routes on PAN-OS devices.
         name: 'Test-One'
         destination: '1.1.1.0/24'
         nexthop: '10.0.0.1'
-    
+
     - name: Create route 'Test-Two'
       panos_static_route:
         ip_address: '{{ fw_ip_address }}'
@@ -52,7 +52,7 @@ Create static routes on PAN-OS devices.
         name: 'Test-Two'
         destination: '2.2.2.0/24'
         nexthop: '10.0.0.1'
-    
+
     - name: Create route 'Test-Three'
       panos_static_route:
         ip_address: '{{ fw_ip_address }}'
@@ -61,7 +61,7 @@ Create static routes on PAN-OS devices.
         name: 'Test-Three'
         destination: '3.3.3.0/24'
         nexthop: '10.0.0.1'
-    
+
     - name: Delete route 'Test-Two'
       panos_static_route:
         ip_address: '{{ fw_ip_address }}'
@@ -69,7 +69,7 @@ Create static routes on PAN-OS devices.
         password: '{{ fw_password }}'
         name: 'Test-Two'
         state: 'absent'
-    
+
     - name: Create route 'Test-Four'
       panos_static_route:
         ip_address: '{{ fw_ip_address }}'
@@ -87,8 +87,8 @@ Create static routes on PAN-OS devices.
         password: '{{ fw_password }}'
         name: 'Test-Five'
         destination: '5.5.5.0/24'
-        # use null for a nexthop type of 'None'
-        nexthop_type: null
+        # use 'none' for a nexthop type of 'None'
+        nexthop_type: none
 
 #### Notes
 

--- a/docs/modules/panos_static_route_module.md
+++ b/docs/modules/panos_static_route_module.md
@@ -27,7 +27,7 @@ Create static routes on PAN-OS devices.
 | metric |  | 10 |  | Metric for route. |
 | name | yes |  |  | Name of static route. |
 | nexthop |  |  |  | Next hop IP address.  Required if *state* is *present*. |
-| nexthop_type |  | ip-address | ip-address, discard | Type of next hop. |
+| nexthop_type |  | ip-address | ip-address, discard, null | Type of next hop. |
 | password |  |  |  | Password for authentication for PAN-OS device.  Optional if *api_key* is used. |
 | state |  | present | present, absent | Create or remove static route. |
 | username |  | admin |  | Username for authentication for PAN-OS device.  Optional if *api_key* is used. |
@@ -79,6 +79,16 @@ Create static routes on PAN-OS devices.
         destination: '4.4.4.0/24'
         nexthop: '10.0.0.1'
         virtual_router: 'VR-Two'
+
+    - name: Create route 'Test-Five'
+      panos_static_route:
+        ip_address: '{{ fw_ip_address }}'
+        username: '{{ fw_username }}'
+        password: '{{ fw_password }}'
+        name: 'Test-Five'
+        destination: '5.5.5.0/24'
+        # use null for a nexthop type of 'None'
+        nexthop_type: null
 
 #### Notes
 

--- a/docs/modules/panos_static_route_module.md
+++ b/docs/modules/panos_static_route_module.md
@@ -87,8 +87,7 @@ Create static routes on PAN-OS devices.
         password: '{{ fw_password }}'
         name: 'Test-Five'
         destination: '5.5.5.0/24'
-        # use 'none' for a nexthop type of 'None'
-        nexthop_type: none
+        nexthop_type: 'none'
 
 #### Notes
 

--- a/examples/fw_static_route_add.yml
+++ b/examples/fw_static_route_add.yml
@@ -46,15 +46,15 @@
       name: 'Test-Two'
       state: 'absent'
 
-- name: Create route 'Test-Four'
-  panos_static_route:
-    ip_address: '{{ fw_ip_address }}'
-    username: '{{ fw_username }}'
-    password: '{{ fw_password }}'
-    name: 'Test-Four'
-    destination: '4.4.4.0/24'
-    nexthop: '10.0.0.1'
-    virtual_router: 'VR-Two'
+  - name: Create route 'Test-Four'
+    panos_static_route:
+      ip_address: '{{ fw_ip_address }}'
+      username: '{{ fw_username }}'
+      password: '{{ fw_password }}'
+      name: 'Test-Four'
+      destination: '4.4.4.0/24'
+      nexthop: '10.0.0.1'
+      virtual_router: 'VR-Two'
 
   - name: Create route 'Test-Five'
     panos_static_route:
@@ -63,5 +63,4 @@
       password: '{{ fw_password }}'
       name: 'Test-Five'
       destination: '5.5.5.0/24'
-      # use null for a nexthop type of 'None'
-      nexthop_type: null
+      nexthop_type: 'none'

--- a/examples/fw_static_route_add.yml
+++ b/examples/fw_static_route_add.yml
@@ -55,3 +55,13 @@
     destination: '4.4.4.0/24'
     nexthop: '10.0.0.1'
     virtual_router: 'VR-Two'
+
+  - name: Create route 'Test-Five'
+    panos_static_route:
+      ip_address: '{{ fw_ip_address }}'
+      username: '{{ fw_username }}'
+      password: '{{ fw_password }}'
+      name: 'Test-Five'
+      destination: '5.5.5.0/24'
+      # use null for a nexthop type of 'None'
+      nexthop_type: null

--- a/library/panos_static_route.py
+++ b/library/panos_static_route.py
@@ -57,7 +57,7 @@ options:
     nexthop_type:
         description:
             - Type of next hop.
-        choices: ['ip-address', 'discard', null]
+        choices: ['ip-address', 'discard', 'none']
         default: 'ip-address'
     nexthop:
         description:
@@ -128,6 +128,15 @@ EXAMPLES = '''
     destination: '4.4.4.0/24'
     nexthop: '10.0.0.1'
     virtual_router: 'VR-Two'
+
+- name: Create route 'Test-Five'
+    panos_static_route:
+    ip_address: '{{ fw_ip_address }}'
+    username: '{{ fw_username }}'
+    password: '{{ fw_password }}'
+    name: 'Test-Five'
+    destination: '5.5.5.0/24'
+    nexthop_type: none
 '''
 
 RETURN = '''
@@ -164,7 +173,7 @@ def main():
         api_key=dict(no_log=True),
         name=dict(type='str', required=True),
         destination=dict(type='str'),
-        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard', '']),
+        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard', 'none']),
         nexthop=dict(type='str'),
         admin_dist=dict(type='str'),
         metric=dict(default='10'),
@@ -193,7 +202,7 @@ def main():
     interface = module.params['interface']
 
     # allow None for nexthop_type
-    nexthop_type = nexthop_type if nexthop_type else None
+    nexthop_type = nexthop_type if nexthop_type.lower() != 'none' else None
 
     changed = False
 

--- a/library/panos_static_route.py
+++ b/library/panos_static_route.py
@@ -57,7 +57,7 @@ options:
     nexthop_type:
         description:
             - Type of next hop.
-        choices: ['ip-address', 'discard']
+        choices: ['ip-address', 'discard', null]
         default: 'ip-address'
     nexthop:
         description:
@@ -164,7 +164,7 @@ def main():
         api_key=dict(no_log=True),
         name=dict(type='str', required=True),
         destination=dict(type='str'),
-        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard']),
+        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard', '']),
         nexthop=dict(type='str'),
         admin_dist=dict(type='str'),
         metric=dict(default='10'),
@@ -191,6 +191,9 @@ def main():
     virtual_router = module.params['virtual_router']
     state = module.params['state']
     interface = module.params['interface']
+
+    # allow None for nexthop_type
+    nexthop_type = nexthop_type if nexthop_type else None
 
     changed = False
 

--- a/library/panos_static_route.py
+++ b/library/panos_static_route.py
@@ -136,7 +136,7 @@ EXAMPLES = '''
     password: '{{ fw_password }}'
     name: 'Test-Five'
     destination: '5.5.5.0/24'
-    nexthop_type: none
+    nexthop_type: 'none'
 '''
 
 RETURN = '''


### PR DESCRIPTION
This PR allows setting a nexthop_type of null in the yaml, which is translated to an empty string, and then interpreted as None.