### PR TITLE
Updated to support Python 3.7 with Paramiko. Bytes decoded to String.

### DIFF
--- a/library/panos_admpwd.py
+++ b/library/panos_admpwd.py
@@ -91,7 +91,7 @@ def wait_with_timeout(module, shell, prompt, timeout=60):
     result = ""
     while True:
         if shell.recv_ready():
-            result += shell.recv(_PROMPTBUFF)
+            result += (shell.recv(_PROMPTBUFF)).decode()
             endresult = result.strip()
             if len(endresult) != 0 and endresult[-1] == prompt:
                 break

--- a/library/panos_static_route.py
+++ b/library/panos_static_route.py
@@ -128,6 +128,16 @@ EXAMPLES = '''
     destination: '4.4.4.0/24'
     nexthop: '10.0.0.1'
     virtual_router: 'VR-Two'
+- name: Create route to Next-VR
+  panos_static_route:
+    ip_address: '{{ fw_ip_address }}'
+    username: '{{ fw_username }}'
+    password: '{{ fw_password }}'
+    name: 'Test-NextVR'
+    destination: '5.5.5.0/24'
+    nexthop: 'vr2_name'
+    virtual_router: 'vr1_name'
+    nexthop_type: 'next-vr'
 '''
 
 RETURN = '''
@@ -164,7 +174,7 @@ def main():
         api_key=dict(no_log=True),
         name=dict(type='str', required=True),
         destination=dict(type='str'),
-        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard']),
+        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard', 'next-vr']),
         nexthop=dict(type='str'),
         admin_dist=dict(type='str'),
         metric=dict(default='10'),

--- a/library/panos_static_route.py
+++ b/library/panos_static_route.py
@@ -128,16 +128,6 @@ EXAMPLES = '''
     destination: '4.4.4.0/24'
     nexthop: '10.0.0.1'
     virtual_router: 'VR-Two'
-- name: Create route to Next-VR
-  panos_static_route:
-    ip_address: '{{ fw_ip_address }}'
-    username: '{{ fw_username }}'
-    password: '{{ fw_password }}'
-    name: 'Test-NextVR'
-    destination: '5.5.5.0/24'
-    nexthop: 'vr2_name'
-    virtual_router: 'vr1_name'
-    nexthop_type: 'next-vr'
 '''
 
 RETURN = '''
@@ -174,7 +164,7 @@ def main():
         api_key=dict(no_log=True),
         name=dict(type='str', required=True),
         destination=dict(type='str'),
-        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard', 'next-vr']),
+        nexthop_type=dict(default='ip-address', choices=['ip-address', 'discard']),
         nexthop=dict(type='str'),
         admin_dist=dict(type='str'),
         metric=dict(default='10'),


### PR DESCRIPTION
It was noticed that the changes from Python 2.7 Paramiko library to 3.x causes the shell object to be returned as bytes in 3.x, and str in 2.7. After setting the object to decode functionality is restored in 3.x (I tested on 3.7). Also, I tested to ensure that decode would not break anything in 2.7.15.