### PR TITLE
Update panos_ike_crypto_profile.py

### DIFF
--- a/library/panos_ike_crypto_profile.py
+++ b/library/panos_ike_crypto_profile.py
@@ -145,7 +145,7 @@ def main():
         api_key=dict(no_log=True),
         state=dict(default='present', choices=['present', 'absent']),
         name=dict(required=True),
-        dhgroup=dict(default='group2'),
+        dhgroup=dict(type='list', default=['group2', 'group19']),
         authentication=dict(default='sha1'),
         encryption=dict(type='list', default=['aes-256-cbc', '3des']),
         lifetime_sec=dict(type='int', default=28800),


### PR DESCRIPTION
I've changed line 148, dhgroup must be a list. Palo alto supports more than one DH group in the same IKE cryto profile