### PR TITLE
panos_ike_crypto_profile bug fixes, expanded options

### DIFF
--- a/docs/modules/panos_ike_crypto_profile_module.md
+++ b/docs/modules/panos_ike_crypto_profile_module.md
@@ -28,12 +28,12 @@ encryption (IKEv1 or IKEv2, Phase 1).
 | state |  | present | present, absent | Create or remove IKE profile. |
 | commit |  | True |  | Commit configuration if changed. |
 | name | yes |  |  | Name for the profile. |
-| dh_group |  | group2 | group1, group2, group5, group14, group19, group20 | Specify the priority for Diffie-Hellman (DH) groups. |
-| authentication |  | sha1 | md5, sha1, sha256, sha384, sha512 | Specify the priority for hash algorithms. |
-| encryption |  | [u'aes-256-cbc', u'3des'] |  | Select the appropriate Encapsulating Security Payload (ESP) authentication options. |
-| lifetime_seconds |  |  | des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc | IKE phase 1 key lifetime in seconds. |
+| dh_group |  | ['group2'] | group1, group2, group5, group14, group19, group20 | Specify the priority for Diffie-Hellman (DH) groups. |
+| authentication |  | ['sha1'] | md5, sha1, sha256, sha384, sha512 | Authentication hashes used for IKE phase 1 proposal. |
+| encryption |  | ['aes-256-cbc', '3des'] | des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc | Encryption algorithms used for IKE phase 1 proposal. |
+| lifetime_seconds |  |  |  | IKE phase 1 key lifetime in seconds. |
 | lifetime_minutes |  |  |  | IKE phase 1 key lifetime in minutes. |
-| lifetime_hours |  |  |  | IKE phase 1 key lifetime in hours. If no key lifetime is specified, default to 8 hours. |
+| lifetime_hours |  | 8 |  | IKE phase 1 key lifetime in hours. If no other key lifetime is specified, default to 8 hours. |
 | lifetime_days |  |  |  | IKE phase 1 key lifetime in days. |
 
 ## Examples

--- a/docs/modules/panos_ike_crypto_profile_module.md
+++ b/docs/modules/panos_ike_crypto_profile_module.md
@@ -21,17 +21,20 @@ encryption (IKEv1 or IKEv2, Phase 1).
 
 | parameter | required | default | choices | comments |
 | --- | --- | --- | --- | --- |
-| api_key |  |  |  | API key that can be used instead of *username*/*password* credentials. |
-| authentication |  | sha1 |  | Specify the priority for hash algorithms. |
-| commit |  | True |  | Commit configuration if changed. |
-| dhgroup |  | group2 |  | Specify the priority for Diffie-Hellman (DH) groups. |
-| encryption |  | [u'aes-256-cbc', u'3des'] |  | Select the appropriate Encapsulating Security Payload (ESP) authentication options. |
 | ip_address | yes |  |  | IP address (or hostname) of PAN-OS device being configured. |
-| lifetime_sec |  | 28800 |  | Select unit of time and enter the length of time that the negotiated IKE Phase 1 key will be effective. |
-| name | yes |  |  | Name for the profile. |
-| password | yes |  |  | Password credentials to use for auth unless *api_key* is set. |
-| state |  | present | present, absent | Create or remove static route. |
 | username |  | admin |  | Username credentials to use for auth unless *api_key* is set. |
+| password | yes |  |  | Password credentials to use for auth unless *api_key* is set. |
+| api_key |  |  |  | API key that can be used instead of *username*/*password* credentials. |
+| state |  | present | present, absent | Create or remove IKE profile. |
+| commit |  | True |  | Commit configuration if changed. |
+| name | yes |  |  | Name for the profile. |
+| dh_group |  | group2 | group1, group2, group5, group14, group19, group20 | Specify the priority for Diffie-Hellman (DH) groups. |
+| authentication |  | sha1 | md5, sha1, sha256, sha384, sha512 | Specify the priority for hash algorithms. |
+| encryption |  | [u'aes-256-cbc', u'3des'] |  | Select the appropriate Encapsulating Security Payload (ESP) authentication options. |
+| lifetime_seconds |  |  | des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc | IKE phase 1 key lifetime in seconds. |
+| lifetime_minutes |  |  |  | IKE phase 1 key lifetime in minutes. |
+| lifetime_hours |  |  |  | IKE phase 1 key lifetime in hours. If no key lifetime is specified, default to 8 hours. |
+| lifetime_days |  |  |  | IKE phase 1 key lifetime in days. |
 
 ## Examples
 
@@ -41,12 +44,11 @@ encryption (IKEv1 or IKEv2, Phase 1).
           username: '{{ username }}'
           password: '{{ password }}'
           state: 'present'
-          name: 'IKE-Ansible'
-          dhgroup: 'group2'
+          name: 'vpn-0cc61dd8c06f95cfd-0'
+          dh_group: 'group2'
           authentication: 'sha1'
-          encryption: ['aes-256-cbc', '3des']
-          lifetime_sec: '28800'
-          commit: 'False'
+          encryption: 'aes-128-cbc'
+          lifetime_seconds: '28800'
 
 #### Notes
 

--- a/docs/modules/panos_ike_crypto_profile_module.md
+++ b/docs/modules/panos_ike_crypto_profile_module.md
@@ -45,9 +45,9 @@ encryption (IKEv1 or IKEv2, Phase 1).
           password: '{{ password }}'
           state: 'present'
           name: 'vpn-0cc61dd8c06f95cfd-0'
-          dh_group: 'group2'
-          authentication: 'sha1'
-          encryption: 'aes-128-cbc'
+          dh_group: ['group2']
+          authentication: ['sha1']
+          encryption: ['aes-128-cbc']
           lifetime_seconds: '28800'
 
 #### Notes

--- a/library/panos_ike_crypto_profile.py
+++ b/library/panos_ike_crypto_profile.py
@@ -147,6 +147,7 @@ def main():
         state=dict(default='present', choices=['present', 'absent']),
         name=dict(required=True),
         dh_group=dict(
+            type='list',
             default='group2',
             choices=[
                 'group1', 'group2', 'group5', 'group14', 'group19', 'group20'

--- a/library/panos_ike_crypto_profile.py
+++ b/library/panos_ike_crypto_profile.py
@@ -74,12 +74,12 @@ options:
         aliases: dhgroup
     authentication:
         description:
-            - Specify the priority for hash algorithms.
+            - Authentication hashes used for IKE phase 1 proposal.
         choices: ['md5', 'sha1', 'sha256', 'sha384', 'sha512']
         default: sha1
     encryption:
         description:
-            - Select the appropriate Encapsulating Security Payload (ESP) authentication options.
+            - Encryption algorithms used for IKE phase 1 proposal.
         choices: ['des', '3des', 'aes-128-cbc', 'aes-192-cbc', 'aes-256-cbc']
         default: ['aes-256-cbc', '3des']
     lifetime_seconds:
@@ -148,7 +148,7 @@ def main():
         name=dict(required=True),
         dh_group=dict(
             type='list',
-            default='group2',
+            default=['group2'],
             choices=[
                 'group1', 'group2', 'group5', 'group14', 'group19', 'group20'
             ],

--- a/library/panos_ike_crypto_profile.py
+++ b/library/panos_ike_crypto_profile.py
@@ -92,7 +92,7 @@ options:
               specified, default to 8 hours.
     lifetime_days:
         description:
-            - IKE phase 1 key lifetime in days. 
+            - IKE phase 1 key lifetime in days.
 '''
 
 EXAMPLES = '''
@@ -191,8 +191,9 @@ def main():
 
     # Reflect GUI behavior.  Default is 8 hour key lifetime if nothing else is
     # specified.
-    if (lifetime_seconds is None and lifetime_minutes is None and
-            lifetime_hours is None and lifetime_days is None):
+    if not any([
+        lifetime_seconds, lifetime_minutes, lifetime_hours, lifetime_days
+    ]):
         lifetime_hours = 8
 
     ike_crypto_prof = network.IkeCryptoProfile(

--- a/library/panos_ike_crypto_profile.py
+++ b/library/panos_ike_crypto_profile.py
@@ -106,9 +106,9 @@ EXAMPLES = '''
       password: '{{ password }}'
       state: 'present'
       name: 'vpn-0cc61dd8c06f95cfd-0'
-      dh_group: 'group2'
-      authentication: 'sha1'
-      encryption: 'aes-128-cbc'
+      dh_group: ['group2']
+      authentication: ['sha1']
+      encryption: ['aes-128-cbc']
       lifetime_seconds: '28800'
 '''
 

--- a/library/panos_ike_crypto_profile.py
+++ b/library/panos_ike_crypto_profile.py
@@ -55,7 +55,7 @@ options:
             - API key that can be used instead of I(username)/I(password) credentials.
     state:
         description:
-            - Create or remove static route.
+            - Create or remove IKE profile.
         choices: ['present', 'absent']
         default: 'present'
     commit:
@@ -70,14 +70,17 @@ options:
         description:
             - Specify the priority for Diffie-Hellman (DH) groups.
         default: group2
+        choices: ['group1', 'group2', 'group5', 'group14', 'group19', 'group20']
         aliases: dhgroup
     authentication:
         description:
             - Specify the priority for hash algorithms.
+        choices: ['md5', 'sha1', 'sha256', 'sha384', 'sha512']
         default: sha1
     encryption:
         description:
             - Select the appropriate Encapsulating Security Payload (ESP) authentication options.
+        choices: ['des', '3des', 'aes-128-cbc', 'aes-192-cbc', 'aes-256-cbc']
         default: ['aes-256-cbc', '3des']
     lifetime_seconds:
         description:
@@ -85,7 +88,7 @@ options:
         aliases: lifetime_sec
     lifetime_minutes:
         description:
-            - IKE phase 1 key lifetime in minutes.  Minimum value is 3 minutes.
+            - IKE phase 1 key lifetime in minutes.
     lifetime_hours:
         description:
             - IKE phase 1 key lifetime in hours.  If no key lifetime is
@@ -102,12 +105,11 @@ EXAMPLES = '''
       username: '{{ username }}'
       password: '{{ password }}'
       state: 'present'
-      name: 'IKE-Ansible'
+      name: 'vpn-0cc61dd8c06f95cfd-0'
       dh_group: 'group2'
       authentication: 'sha1'
-      encryption: ['aes-256-cbc', '3des']
+      encryption: 'aes-128-cbc'
       lifetime_seconds: '28800'
-      commit: 'False'
 '''
 
 RETURN = '''
@@ -118,10 +120,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import get_exception
 
 try:
-    from pan.xapi import PanXapiError
-    import pandevice
     from pandevice import base
-    from pandevice import panorama
     from pandevice.errors import PanDeviceError
     from pandevice import network
 
@@ -147,9 +146,27 @@ def main():
         api_key=dict(no_log=True),
         state=dict(default='present', choices=['present', 'absent']),
         name=dict(required=True),
-        dh_group=dict(default='group2', aliases=['dhgroup']),
-        authentication=dict(type='list', default=['sha1']),
-        encryption=dict(type='list', default=['aes-256-cbc', '3des']),
+        dh_group=dict(
+            default='group2',
+            choices=[
+                'group1', 'group2', 'group5', 'group14', 'group19', 'group20'
+            ],
+            aliases=['dhgroup']
+        ),
+        authentication=dict(
+            type='list',
+            choices=[
+                'md5', 'sha1', 'sha256', 'sha384', 'sha512'
+            ],
+            default=['sha1']
+        ),
+        encryption=dict(
+            type='list',
+            choices=[
+                'des', '3des', 'aes-128-cbc', 'aes-192-cbc', 'aes-256-cbc'
+            ],
+            default=['aes-256-cbc', '3des']
+        ),
         lifetime_seconds=dict(type='int', aliases=['lifetime_sec']),
         lifetime_minutes=dict(type='int'),
         lifetime_hours=dict(type='int'),


### PR DESCRIPTION
- Fix DH group always being 'group2'.
- Expand key lifetime options.
- Align option names with pandevice.  Old names preserved as aliases.