### PR TITLE
Updating panos_ipsec_tunnel

### DIFF
--- a/library/panos_ipsec_tunnel.py
+++ b/library/panos_ipsec_tunnel.py
@@ -63,6 +63,7 @@ options:
         description:
             - Type of IPsec tunnel.
         choices: ['auto-key', 'manual-key', or 'global-protect-satellite']
+        default: 'auto-key'
     ak_ike_gateway:
         description:
             - Name of the existing IKE gateway (auto-key).
@@ -104,7 +105,7 @@ options:
              – Authentication key (manual-key).
     mk_esp_encryption:
         description:
-            - Encryption algorithm for tunnel traffic (manual-key). 
+            - Encryption algorithm for tunnel traffic (manual-key).
         choices: ['des', '3des', 'aes-128-cbc', 'aes-192-cbc', 'aes-256-cbc', 'null']
     mk_esp_encryption_key:
         description:
@@ -219,7 +220,7 @@ def main():
             tunnel_interface=dict(default='tunnel.1'),
             anti_replay=dict(type=bool, default=True),
             ipv6=dict(type=bool, default=False),
-            type=dict(type='str', choices=['auto-key', 'manual-key', 'global-protect-satellite']),
+            type=dict(type='str', choices=['auto-key', 'manual-key', 'global-protect-satellite'], default='auto-key'),
             ak_ike_gateway=dict(default='default', aliases=['ike_gtw_name']),
             ak_ipsec_crypto_profile=dict(default='default', aliases=['ipsec_profile']),
             mk_local_spi=dict(type='str', default=None),

--- a/library/panos_ipsec_tunnel.py
+++ b/library/panos_ipsec_tunnel.py
@@ -50,16 +50,113 @@ options:
         description:
             - Specify existing tunnel interface that will be used.
         default: 'tunnel.1'
+    anti_replay:
+        description:
+            - Enable anti-replay check on this tunnel.
+        default: True
+    ipv6:
+        description:
+            - Use IPv6 for the IPsec tunnel (7.0+)
+        type: bool
+        default: False
+    type:
+        description:
+            - Type of IPsec tunnel.
+        choices: ['auto-key', 'manual-key', or 'global-protect-satellite']
     ak_ike_gateway:
         description:
-            - Name of the existing IKE gateway.
+            - Name of the existing IKE gateway (auto-key).
         default: 'default'
         aliases: 'ike_gtw_name'
     ak_ipsec_crypto_profile:
         description:
-            - Name of the existing IPsec profile or use default.
+            - Name of the existing IPsec profile or use default (auto-key).
         default: 'default'
         aliases: 'ipsec_profile'
+    mk_local_spi:
+        description:
+            - Outbound SPI in hex (manual-key).
+    mk_interface:
+        description:
+             – Interface to terminate tunnel (manual-key).
+    mk_remote_spi:
+        description:
+             – Inbound SPI in hex (manual-key).
+    mk_remote_address:
+        description:
+             – Tunnel peer IP address (manual-key).
+    mk_local_address_ip:
+        description:
+             – Exact IP address if interface has multiple IP addresses (manual-key).
+    mk_local_address_floating_ip:
+        description:
+             – Floating IP address in HA Active-Active configuration (manual-key).
+    mk_protocol:
+        description:
+            – Protocol for traffic through the tunnel (manual-key).
+        choices: ['esp', 'ah']
+    mk_auth_type:
+        description:
+            - Authentication type for tunnel access (manual-key).
+        choices: ['md5', 'sha1', 'sha256', 'sha384', 'sha512']
+    mk_auth_key:
+        description:
+             – Authentication key (manual-key).
+    mk_esp_encryption:
+        description:
+            - Encryption algorithm for tunnel traffic (manual-key). 
+        choices: ['des', '3des', 'aes-128-cbc', 'aes-192-cbc', 'aes-256-cbc', 'null']
+    mk_esp_encryption_key:
+        description:
+            - Encryption key (manual-key).
+    gps_portal_address:
+        description:
+             – GlobalProtect portal address (global-protect-satellite).
+    gps_prefer_ipv6:
+        description:
+             – Prefer to register portal in IPv6 (8.0+) (global-protect-satellite).
+        type: bool
+        default: False
+    gps_interface:
+        description:
+            – Interface to communicate with portal (global-protect-satellite).
+    gps_interface_ipv4_ip:
+        description:
+            – Exact IPv4 IP address if interface has multiple IP addresses (global-protect-satellite).
+    gps_interface_ipv6_ip:
+        description:
+             – Exact IPv6 IP address if interface has multiple IP addresses (8.0+) (global-protect-satellite).
+    gps_interface_ipv4_floating_ip:
+        description:
+            – Floating IPv4 IP address in HA Active-Active configuration (7.0+) (global-protect-satellite).
+    gps_interface_ipv6_floating_ip:
+        description:
+            – Floating IPv6 IP address in HA Active-Active configuration (8.0+) (global-protect-satellite).
+    gps_publish_connected_routes:
+        description:
+            – Enable publishing of connected and static routes (global-protect-satellite).
+        type: bool
+        default: False
+    gps_publish_routes:
+        description:
+            - Specify list of routes to publish to GlobalProtect gateway (global-protect-satellite).
+        type: list
+    gps_local_certificate:
+        description:
+            - GlobalProtect satellite certificate file name (global-protect-satellite).
+    gps_certificate_profile:
+        description:
+            – Profile for authenticating GlobalProtect gateway certificates (global-protect-satellite).
+    copy_tos:
+        description:
+            - Copy IP TOS bits from inner packet to IPSec packet (not recommended).
+        type: bool
+        default: False
+    copy_flow_label:
+        description:
+            – Copy IPv6 flow label for 6in6 tunnel from inner packet to IPSec packet (not recommended) (7.0+).
+        type: bool
+        default: False
     enable_tunnel_monitor:
         description:
             - Enable tunnel monitoring on this tunnel.
@@ -120,8 +217,41 @@ def main():
         argument_spec=dict(
             name=dict(required=True),
             tunnel_interface=dict(default='tunnel.1'),
+            anti_replay=dict(type=bool, default=True),
+            ipv6=dict(type=bool, default=False),
+            type=dict(type='str', choices=['auto-key', 'manual-key', 'global-protect-satellite']),
             ak_ike_gateway=dict(default='default', aliases=['ike_gtw_name']),
             ak_ipsec_crypto_profile=dict(default='default', aliases=['ipsec_profile']),
+            mk_local_spi=dict(type='str', default=None),
+            mk_interface=dict(type='str', default=None),
+            mk_remote_spi=dict(type='str', default=None),
+            mk_remote_address=dict(type='str', default=None),
+            mk_local_address_ip=dict(type='str', default=None),
+            mk_local_address_floating_ip=dict(type='str', default=None),
+            mk_protocol=dict(type='str', default=None, choices=['esp', 'ah']),
+            mk_auth_type=dict(type='str', default=None, choices=['md5', 'sha1', 'sha256', 'sha384', 'sha512']),
+            mk_auth_key=dict(type='str', default=None),
+            mk_esp_encryption=dict(
+                type='str',
+                default=None,
+                choices=[
+                    'des', '3des', 'aes-128-cbc', 'aes-192-cbc', 'aes-256-cbc', 'null'
+                ]
+            ),
+            mk_esp_encryption_key=dict(type='str', default=None),
+            gps_portal_address=dict(type='str', default=None),
+            gps_prefer_ipv6=dict(type='bool', default=False),
+            gps_interface=dict(type='str', default=None),
+            gps_interface_ipv4_ip=dict(type='str', default=None),
+            gps_interface_ipv6_ip=dict(type='str', default=None),
+            gps_interface_ipv4_floating_ip=dict(type='str', default=None),
+            gps_interface_ipv6_floating_ip=dict(type='str', default=None),
+            gps_publish_connected_routes=dict(type='bool', default=False),
+            gps_publish_routes=dict(type='bool', default=False),
+            gps_local_certificate=dict(type='str', default=None),
+            gps_certificate_profile=dict(type='str', default=None),
+            copy_tos=dict(type='bool', default=False),
+            copy_flow_label=dict(type='bool', default=False),
             enable_tunnel_monitor=dict(type='bool', default=False),
             tunnel_monitor_dest_ip=dict(type='str', default=None),
             tunnel_monitor_proxy_id=dict(type='str', default=None),
@@ -144,8 +274,32 @@ def main():
     spec = {
         'name': module.params['name'],
         'tunnel_interface': module.params['tunnel_interface'],
+        'anti_replay': module.params['anti_replay'],
+        'ipv6': module.params['ipv6'],
         'ak_ike_gateway': module.params['ak_ike_gateway'],
         'ak_ipsec_crypto_profile': module.params['ak_ipsec_crypto_profile'],
+        'mk_local_spi': module.params['mk_local_spi'],
+        'mk_interface': module.params['mk_interface'],
+        'mk_remote_spi': module.params['mk_remote_spi'],
+        'mk_remote_address': module.params['mk_remote_address'],
+        'mk_local_address_ip': module.params['mk_local_address_ip'],
+        'mk_local_address_floating_ip': module.params['mk_local_address_floating_ip'],
+        'mk_protocol': module.params['mk_protocol'],
+        'mk_auth_type': module.params['mk_auth_type'],
+        'mk_auth_key': module.params['mk_auth_key'],
+        'mk_esp_encryption': module.params['mk_esp_encryption'],
+        'mk_esp_encryption_key': module.params['mk_esp_encryption_key'],
+        'gps_portal_address': module.params['gps_portal_address'],
+        'gps_prefer_ipv6': module.params['gps_prefer_ipv6'],
+        'gps_interface': module.params['gps_interface'],
+        'gps_interface_ipv6_ip': module.params['gps_interface_ipv6_ip'],
+        'gps_interface_ipv4_floating_ip': module.params['gps_interface_ipv4_floating_ip'],
+        'gps_publish_connected_routes': module.params['gps_publish_connected_routes'],
+        'gps_publish_routes': module.params['gps_publish_routes'],
+        'gps_local_certificate': module.params['gps_local_certificate'],
+        'gps_certificate_profile': module.params['gps_certificate_profile'],
+        'copy_tos': module.params['copy_tos'],
+        'copy_flow_label': module.params['copy_flow_label'],
         'enable_tunnel_monitor': module.params['enable_tunnel_monitor'],
         'tunnel_monitor_dest_ip': module.params['tunnel_monitor_dest_ip'],
         'tunnel_monitor_proxy_id': module.params['tunnel_monitor_proxy_id'],

--- a/library/panos_ipsec_tunnel.py
+++ b/library/panos_ipsec_tunnel.py
@@ -35,33 +35,13 @@ requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)
 notes:
-    - Checkmode is not supported.
-    - Panorama is NOT supported.
+    - Panorama is supported.
+    - Check mode is supported.
+extends_documentation_fragment:
+    - panos.transitional_provider
+    - panos.state
+    - panos.full_template_support
 options:
-    ip_address:
-        description:
-            - IP address (or hostname) of PAN-OS device being configured.
-        required: true
-    username:
-        description:
-            - Username credentials to use for auth unless I(api_key) is set.
-        default: "admin"
-    password:
-        description:
-            - Password credentials to use for auth unless I(api_key) is set.
-        required: true
-    api_key:
-        description:
-            - API key that can be used instead of I(username)/I(password) credentials.
-    state:
-        description:
-            - Create or remove static route.
-        choices: ['present', 'absent']
-        default: 'present'
-    commit:
-        description:
-            - Commit configuration if changed.
-        default: true
     name:
         description:
             - Name for the IPSec tunnel.
@@ -70,28 +50,51 @@ options:
         description:
             - Specify existing tunnel interface that will be used.
         default: 'tunnel.1'
-    ike_gtw_name:
+    ak_ike_gateway:
         description:
             - Name of the existing IKE gateway.
         default: 'default'
-    ipsec_profile:
+        aliases: 'ike_gtw_name'
+    ak_ipsec_crypto_profile:
         description:
             - Name of the existing IPsec profile or use default.
         default: 'default'
+        aliases: 'ipsec_profile'
+    enable_tunnel_monitor:
+        description:
+            - Enable tunnel monitoring on this tunnel.
+        default: False
+    tunnel_monitor_dest_ip:
+        description:
+            - Destination IP to send ICMP probe.
+    tunnel_monitor_proxy_id:
+        description:
+            - Which proxy-id (or proxy-id-v6) the monitoring traffic will use.
+        default: None
+    tunnel_monitor_profile:
+        description:
+            - Monitoring action.
+        default: None
+    disabled:
+        description:
+            - Disable the IPsec tunnel.
+        default: False
+    commit:
+        description:
+            - Commit configuration if changed.
+        default: True
 '''
 
 EXAMPLES = '''
 - name: Add IPSec tunnel to IKE gateway profile
-    panos_ipsec_tunnel:
-      ip_address: '{{ ip_address }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      state: 'present'
-      name: 'IPSecTunnel-Ansible'
-      tunnel_interface: 'tunnel.2'
-      ike_gtw_name: 'IKEGW-Ansible'
-      ipsec_profile: 'IPSec-Ansible'
-      commit: 'False'
+  panos_ipsec_tunnel:
+    provider: '{{ provider }}'
+    name: 'IPSecTunnel-Ansible'
+    tunnel_interface: 'tunnel.2'
+    ak_ike_gateway: 'IKEGW-Ansible'
+    ak_ipsec_crypto_profile: 'IPSec-Ansible'
+    state: 'present'
+    commit: False
 '''
 
 RETURN = '''
@@ -99,120 +102,78 @@ RETURN = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import get_exception
+from ansible.module_utils.network.panos.panos import get_connection
 
 try:
-    from pan.xapi import PanXapiError
-    import pandevice
-    from pandevice import base
-    from pandevice import panorama
+    from pandevice.network import IpsecTunnel
     from pandevice.errors import PanDeviceError
-    from pandevice import network
-
-    HAS_LIB = True
 except ImportError:
-    HAS_LIB = False
-
-
-# def get_devicegroup(device, devicegroup):
-#     dg_list = device.refresh_devices()
-#     for group in dg_list:
-#         if isinstance(group, pandevice.panorama.DeviceGroup):
-#             if group.name == devicegroup:
-#                 return group
-#     return False
-
-
-class IPSecTunnel:
-    def __init__(self, *args, **kwargs):
-        self.name = kwargs.get('name')
-        self.key_type = 'auto-key'
-        self.tunnel_interface = kwargs.get('tunnel_interface')
-        self.ike_gw = args[0]
-        self.ipsec_profile = args[1]
+    pass
 
 
 def main():
-    argument_spec = dict(
-        ip_address=dict(required=True),
-        password=dict(no_log=True),
-        username=dict(default='admin'),
-        api_key=dict(no_log=True),
-        state=dict(default='present', choices=['present', 'absent']),
-        name=dict(required=True),
-        tunnel_interface=dict(default='tunnel.1'),
-        ike_gtw_name=dict(default='default'),
-        ipsec_profile=dict(default='default'),
-        commit=dict(type='bool', default=True)
+    helper = get_connection(
+        template=True,
+        template_stack=True,
+        with_classic_provider_spec=True,
+        with_state=True,
+        argument_spec=dict(
+            name=dict(required=True),
+            tunnel_interface=dict(default='tunnel.1'),
+            ak_ike_gateway=dict(default='default', aliases=['ike_gtw_name']),
+            ak_ipsec_crypto_profile=dict(default='default', aliases=['ipsec_profile']),
+            enable_tunnel_monitor=dict(type='bool', default=False),
+            tunnel_monitor_dest_ip=dict(type='str', default=None),
+            tunnel_monitor_proxy_id=dict(type='str', default=None),
+            tunnel_monitor_profile=dict(type='str', default=None),
+            disabled=dict(type='bool', default=False),
+            commit=dict(type='bool', default=True)
+        )
     )
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,
-                           required_one_of=[['api_key', 'password']])
-    if not HAS_LIB:
-        module.fail_json(msg='Missing required libraries.')
 
-    ip_address = module.params['ip_address']
-    password = module.params['password']
-    username = module.params['username']
-    api_key = module.params['api_key']
-    state = module.params['state']
-    name = module.params['name']
-    tunnel_interface = module.params['tunnel_interface']
-    ike_gtw_name = module.params['ike_gtw_name']
-    ipsec_profile = module.params['ipsec_profile']
+    module = AnsibleModule(
+        argument_spec=helper.argument_spec,
+        supports_check_mode=True,
+        required_one_of=helper.required_one_of
+    )
+
+    # Verify libs are present, get parent object.
+    parent = helper.get_pandevice_parent(module)
+
+    # Object params.
+    spec = {
+        'name': module.params['name'],
+        'tunnel_interface': module.params['tunnel_interface'],
+        'ak_ike_gateway': module.params['ak_ike_gateway'],
+        'ak_ipsec_crypto_profile': module.params['ak_ipsec_crypto_profile'],
+        'enable_tunnel_monitor': module.params['enable_tunnel_monitor'],
+        'tunnel_monitor_dest_ip': module.params['tunnel_monitor_dest_ip'],
+        'tunnel_monitor_proxy_id': module.params['tunnel_monitor_proxy_id'],
+        'tunnel_monitor_profile': module.params['tunnel_monitor_profile'],
+        'disabled': module.params['disabled']
+    }
+
+    # Other info.
     commit = module.params['commit']
 
-    # If Panorama, validate the devicegroup
-    # dev_group = None
-    # if devicegroup and isinstance(device, panorama.Panorama):
-    #     dev_group = get_devicegroup(device, devicegroup)
-    #     if dev_group:
-    #         device.add(dev_group)
-    #     else:
-    #         module.fail_json(msg='\'%s\' device group not found in Panorama. Is the name correct?' % devicegroup)
-
-    ipsecTunnel = IPSecTunnel(ike_gtw_name, ipsec_profile, name=name,
-                              tunnel_interface=tunnel_interface)
-
-    ipsec_tunnel = network.IpsecTunnel(name=ipsecTunnel.name, tunnel_interface=ipsecTunnel.tunnel_interface,
-                                       type=ipsecTunnel.key_type,
-                                       ak_ike_gateway=ipsecTunnel.ike_gw,
-                                       ak_ipsec_crypto_profile=ipsecTunnel.ipsec_profile,
-                                       ipv6=False,
-                                       enable_tunnel_monitor=False,
-                                       disabled=False)
-
-    # Create the device with the appropriate pandevice type
-    device = base.PanDevice.create_from_device(ip_address, username, password, api_key=api_key)
-
-    changed = False
+    # Retrieve current info.
     try:
-        # fetch all Ipsec tunnels
-        tunnels = network.IpsecTunnel.refreshall(device)
-        if state == "present":
-            device.add(ipsec_tunnel)
-            for t in tunnels:
-                if t.name == ipsec_tunnel.name:
-                    if not ipsec_tunnel.equal(t):
-                        ipsec_tunnel.apply()
-                        changed = True
-            else:
-                ipsec_tunnel.create()
-                changed = True
-        elif state == "absent":
-            ipsec_tunnel = device.find(ipsec_tunnel.name, network.IpsecTunnel)
-            if ipsec_tunnel:
-                ipsec_tunnel.delete()
-                changed = True
-        else:
-            module.fail_json(msg='[%s] state is not implemented yet' % state)
-    except PanDeviceError:
-        exc = get_exception()
-        module.fail_json(msg=exc.message)
+        listing = IpsecTunnel.refreshall(parent, add=False)
+    except PanDeviceError as e:
+        module.fail_json(msg='Failed refresh: {0}'.format(e))
 
+    obj = IpsecTunnel(**spec)
+    parent.add(obj)
+
+    # Apply the state.
+    changed = helper.apply_state(obj, listing, module)
+
+    # Commit.
     if commit and changed:
-        device.commit(sync=True)
+        helper.commit(module)
 
-    module.exit_json(msg='ipsec tunnel config successful.', changed=changed)
+    # Done.
+    module.exit_json(changed=changed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#269 

- Unify option names with pandevice.  Old option names are preserved as
  aliases.

- Supports tunnel monitor options.  Fixes #219.