### PR TITLE
fix conditions for arguments in panos_match_rule

### DIFF
--- a/library/panos_match_rule.py
+++ b/library/panos_match_rule.py
@@ -271,7 +271,7 @@ def main():
         username=dict(default='admin'),
         api_key=dict(no_log=True),
         vsys_id=dict(default='vsys1'),
-        rule_type=dict(required=True, choices=['security', 'nat']),
+        rule_type=dict(default='security', choices=['security', 'nat']),
         source_zone=dict(default=None),
         source_ip=dict(default=None),
         source_user=dict(default=None),

--- a/library/panos_match_rule.py
+++ b/library/panos_match_rule.py
@@ -74,15 +74,18 @@ options:
     destination_ip:
         description:
             - The destination IP address.
+        required: true
     destination_port:
         description:
             - The destination port.
+        required: true
     application:
         description:
             - The application.
     protocol:
         description:
             - The IP protocol number from 1 to 255.
+        required: true
     category:
         description:
             - URL category
@@ -280,9 +283,9 @@ def main():
         destination_zone=dict(default=None),
         category=dict(default=None),
         application=dict(default=None),
-        protocol=dict(default=None, type=int),
-        destination_ip=dict(default=None),
-        destination_port=dict(default=None, type=int)
+        protocol=dict(required=True, type=int),
+        destination_ip=dict(required=True),
+        destination_port=dict(required=True, type=int)
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,
                            required_one_of=[['api_key', 'password']])


### PR DESCRIPTION
it appears that the condition declared for `rule_type` argument in `panos_match_rule` doesn't match with doc.

* docs
```
    rule_type:
        description:
            - Type of rule. Valid types are I(security) or I(nat).
        default: "security"
```

* actual code
```python
rule_type=dict(required=True, choices=['security', 'nat']),
```

so i think either one of them should be fixed.
this PR fixes actual `rule_type` definition, since i believe its expected to work as defined under docs.

thanks.