### PR TITLE
Show register_ip_facts based on ip addresses

### DIFF
--- a/docs/modules/panos_registered_ip_facts_module.rst
+++ b/docs/modules/panos_registered_ip_facts_module.rst
@@ -218,6 +218,20 @@ Parameters
                                                                         <div>List of tags to retrieve facts for.  If not specified, retrieve all tags.</div>
                                                                                 </td>
             </tr>
+
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>ips</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>List of IP addresses to retrieve facts for.  If not specified, retrieve all addresses.</div>
+                                                                                </td>
+            </tr>
                                 <tr>
                                                                 <td colspan="2">
                     <b>username</b>
@@ -278,6 +292,12 @@ Examples
         provider: '{{ provider }}'
         tags: ['First_Tag']
       register: first_tag_registered_ip_facts
+
+    - name: Get facts for specific tag
+      panos_registered_ip_facts:
+        provider: '{{ provider }}'
+        ips: ['192.168.1.1']
+      register: ipaddress_registered_ip_facts
 
 
 

--- a/examples/fw_registered_ip_facts.yml
+++ b/examples/fw_registered_ip_facts.yml
@@ -23,3 +23,11 @@
       password: '{{ fw_password }}'
       tags: ['First_Tag']
     register: first_tag_registered_ip_facts
+
+  - name: Get facts for specific IP address
+    panos_registered_ip_facts:
+      ip_address: '{{ fw_ip_address }}'
+      username: '{{ fw_username }}'
+      password: '{{ fw_password }}'
+      ips: [ '192.168.1.1' ]
+    register: ipaddress_registered_ip_facts

--- a/library/panos_registered_ip_facts.py
+++ b/library/panos_registered_ip_facts.py
@@ -41,6 +41,9 @@ options:
     tags:
         description:
             - List of tags to retrieve facts for.  If not specified, retrieve all tags.
+    ips:
+        description:
+            - List of IP addresses to retrieve facts for.  If not specified, retrieve all addresses.
 '''
 
 EXAMPLES = '''

--- a/library/panos_registered_ip_facts.py
+++ b/library/panos_registered_ip_facts.py
@@ -79,7 +79,8 @@ def main():
         with_classic_provider_spec=True,
         panorama_error='Panorama is not supported for this module.',
         argument_spec=dict(
-            tags=dict(type='list')
+            tags=dict(type='list'),
+            ips=dict(type='list')
         )
     )
 
@@ -89,11 +90,12 @@ def main():
     )
 
     tags = module.params['tags']
+    ips = module.params['ips']
 
     device = helper.get_pandevice_parent(module)
 
     try:
-        registered_ips = device.userid.get_registered_ip(tags=tags)
+        registered_ips = device.userid.get_registered_ip(tags=tags, ip=ips)
 
     except PanDeviceError as e:
         module.fail_json(msg='Failed get_registered_ip: {0}'.format(e))


### PR DESCRIPTION
the low level function supports requesting registered ips
and tags based on IP-addresses.
This patch implements that for the registered_ip_facts task