### PR TITLE
Fix logic for template stack usage

### DIFF
--- a/module_utils/network/panos/panos.py
+++ b/module_utils/network/panos/panos.py
@@ -209,7 +209,7 @@ class ConnectionHelper(object):
                         ))
                 elif tmpl_required:
                     module.fail_json(msg=ts_error.format(''))
-                else:
+                elif not added_template:
                     module.fail_json(msg=pano_mia_param.format(self.template))
 
             # Spec: vsys_dg or device_group.


### PR DESCRIPTION
This is a solution to #398.

If a template stack has been identified (and hence `added_template` is set to True), then `module.params[self.template]` can be set to `None` (`template` is not a required parameter).