### PR TITLE
Fix panosinterface bug

### DIFF
--- a/library/panos_interface.py
+++ b/library/panos_interface.py
@@ -286,7 +286,7 @@ def main():
         'ipv4_mss_adjust': module.params['ipv4_mss_adjust'],
         'ipv6_mss_adjust': module.params['ipv6_mss_adjust'],
         'enable_dhcp': True if module.params['enable_dhcp'] else None,
-        'create_dhcp_default_route': True if module.params['create_default_route'] else None,
+        'create_dhcp_default_route': True if module.params['create_default_route'] else False,
         'dhcp_default_route_metric': module.params['dhcp_default_route_metric'],
     }
 

--- a/library/panos_interface.py
+++ b/library/panos_interface.py
@@ -285,16 +285,17 @@ def main():
         'comment': module.params['comment'],
         'ipv4_mss_adjust': module.params['ipv4_mss_adjust'],
         'ipv6_mss_adjust': module.params['ipv6_mss_adjust'],
-        'enable_dhcp': (module.params['enable_dhcp']
-                        if isinstance(module.params['enable_dhcp'], bool)
-                        else None),
-        'create_dhcp_default_route': (module.params['create_default_route']
-                                      if module.params['create_default_route']
-                                      or (module.params['enable_dhcp']
-                                          and isinstance(module.params['create_default_route'], bool))
-                                      else None),
+        'enable_dhcp': True if module.params['enable_dhcp'] else None,
+        # 'create_dhcp_default_route': set below
         'dhcp_default_route_metric': module.params['dhcp_default_route_metric'],
     }
+
+    if module.params['create_default_route']:
+        spec['create_dhcp_default_route'] = True
+    elif spec['enable_dhcp']:
+        spec['create_dhcp_default_route'] = False
+    else:
+        spec['create_dhcp_default_route'] = None
 
     # Get other info.
     state = module.params['state']

--- a/library/panos_interface.py
+++ b/library/panos_interface.py
@@ -285,7 +285,7 @@ def main():
         'comment': module.params['comment'],
         'ipv4_mss_adjust': module.params['ipv4_mss_adjust'],
         'ipv6_mss_adjust': module.params['ipv6_mss_adjust'],
-        'enable_dhcp': True if module.params['enable_dhcp'] else None,
+        'enable_dhcp': True if module.params['enable_dhcp'] else False,
         'create_dhcp_default_route': True if module.params['create_default_route'] else False,
         'dhcp_default_route_metric': module.params['dhcp_default_route_metric'],
     }

--- a/library/panos_interface.py
+++ b/library/panos_interface.py
@@ -285,8 +285,14 @@ def main():
         'comment': module.params['comment'],
         'ipv4_mss_adjust': module.params['ipv4_mss_adjust'],
         'ipv6_mss_adjust': module.params['ipv6_mss_adjust'],
-        'enable_dhcp': True if module.params['enable_dhcp'] else False,
-        'create_dhcp_default_route': True if module.params['create_default_route'] else False,
+        'enable_dhcp': (module.params['enable_dhcp']
+                        if isinstance(module.params['enable_dhcp'], bool)
+                        else None),
+        'create_dhcp_default_route': (module.params['create_default_route']
+                                      if module.params['create_default_route']
+                                      or (module.params['enable_dhcp']
+                                          and isinstance(module.params['create_default_route'], bool))
+                                      else None),
         'dhcp_default_route_metric': module.params['dhcp_default_route_metric'],
     }
 


### PR DESCRIPTION
This is a fix for #411.

Setting `enable_dhcp` and `create_dhcp_default_route` to `None` if the module params for these values are not set to `True` does not yield the desired effect. The proposed fix sets them both to `False` unless the module params are set to `True`.