### PR TITLE
Fix example variable names

### DIFF
--- a/docs/modules/panos_nat_rule_module.rst
+++ b/docs/modules/panos_nat_rule_module.rst
@@ -683,8 +683,8 @@ Examples
         rule_name: "Web SSH"
         source_zone: ["external"]
         destination_zone: "external"
-        source: ["any"]
-        destination: ["10.0.0.100"]
+        source_ip: ["any"]
+        destination_ip: ["10.0.0.100"]
         service: "service-tcp-221"
         snat_type: "dynamic-ip-and-port"
         snat_interface: "ethernet1/2"


### PR DESCRIPTION
The example on this doc has `destination` and `source` but it should actually be `destination_ip` and `source_ip`