### PR TITLE
Added so you can search after IP in address object instead of name

### DIFF
--- a/library/panos_object_facts.py
+++ b/library/panos_object_facts.py
@@ -47,6 +47,14 @@ options:
         description:
             - A python regex for an object's name to retrieve.
             - Mutually exclusive with I(name).
+    value:
+        description:
+            - IP of object to retrieve.
+            - Mutually exclusive with I(value_regex).
+    value_regex:
+        description:
+            - A python regex for an object's IP to retrieve.
+            - Mutually exclusive with I(value).
     object_type:
         description:
             - Type of object to retrieve.
@@ -131,7 +139,7 @@ def colorize(obj, object_type):
 
 
 def main():
-    name_params = ['name', 'name_regex']
+    name_params = ['name', 'name_regex','value','value_regex']
     obj_types = {
         'address': objects.AddressObject,
         'address-group': objects.AddressGroup,
@@ -147,6 +155,8 @@ def main():
         argument_spec=dict(
             name=dict(),
             name_regex=dict(),
+            value=dict(),
+            value_regex=dict(),
             object_type=dict(default='address', choices=obj_types.keys()),
         ),
     )
@@ -175,6 +185,21 @@ def main():
         if obj:
             results = colorize(obj, object_type)
             ans_objects.append(results)
+    elif module.params['value'] is not None:    
+        for x in obj_listing:
+            AdressObject = x.about()
+            if AdressObject['value'] == module.params['value']:
+                ans_objects.append(colorize(x, object_type))
+    elif module.params['value_regex'] is not None:   
+        try:
+            matcher = re.compile(module.params['value_regex'])
+        except Exception as e:
+            module.fail_json(msg='Invalid regex: {0}'.format(e))
+
+        for x in obj_listing:
+            AdressObject = x.about()
+            if matcher.search(AdressObject['value']) is not None:
+                ans_objects.append(colorize(x, object_type))
     else:
         try:
             matcher = re.compile(module.params['name_regex'])

--- a/library/panos_object_facts.py
+++ b/library/panos_object_facts.py
@@ -185,7 +185,7 @@ def main():
         if obj:
             results = colorize(obj, object_type)
             ans_objects.append(results)
-    elif module.params['value'] is not None:   
+    elif module.params['value'] is not None:
         for x in obj_listing:
             AdressObject = x.about()
             if AdressObject['value'] == module.params['value']:

--- a/library/panos_object_facts.py
+++ b/library/panos_object_facts.py
@@ -139,7 +139,7 @@ def colorize(obj, object_type):
 
 
 def main():
-    name_params = ['name', 'name_regex','value','value_regex']
+    name_params = ['name', 'name_regex', 'value', 'value_regex']
     obj_types = {
         'address': objects.AddressObject,
         'address-group': objects.AddressGroup,
@@ -185,12 +185,12 @@ def main():
         if obj:
             results = colorize(obj, object_type)
             ans_objects.append(results)
-    elif module.params['value'] is not None:    
+    elif module.params['value'] is not None:   
         for x in obj_listing:
             AdressObject = x.about()
             if AdressObject['value'] == module.params['value']:
                 ans_objects.append(colorize(x, object_type))
-    elif module.params['value_regex'] is not None:   
+    elif module.params['value_regex'] is not None:
         try:
             matcher = re.compile(module.params['value_regex'])
         except Exception as e:


### PR DESCRIPTION
Like the title saids. To search after IP instead of name in Addresses. Instead of using name/name_regex you use value/value_regex. It will also solve issue number #66 

Exemple : 

```
  - name: Get address object with IP with value
    panos_object_facts:
      provider:
        ip_address: '{{ ansible_host }}'
        username: '{{ username_fw }}'
        password: '{{ password_fw }}'
      object_type: 'address'
      value: '192.168.0.0/24'
    register: results
  - debug: msg='{{ results }}'
```

output : 

```
ok: [fwtest] => {
    "msg": {
        "ansible_module_results": {},
        "changed": false,
        "failed": false,
        "objects": [
            {
                "description": null,
                "name": "localnet",
                "tag": [
                    "local"
                ],
                "type": "ip-netmask",
                "value": "192.168.0.0/24"
            }
        ]
    }
}
```

Or with value_regex : 

```
  - name: Get address object with IP with value_regex
    panos_object_facts:
      provider:
        ip_address: '{{ ansible_host }}'
        username: '{{ username_fw }}'
        password: '{{ password_fw }}'
      object_type: 'address'
      value_regex: '172.168.229.*'
    register: results
  - debug: msg='{{ results }}'
```


Output : 

```
ok: [fwtest] => {
    "msg": {
        "ansible_module_results": {},
        "changed": false,
        "failed": false,
        "objects": [
            {
                "description": null,
                "name": "gw",
                "tag": [
                    "gw"
                ],
                "type": "ip-netmask",
                "value": "172.168.229.1/24"
            },
            {
                "description": null,
                "name": "172.168.229.54",
                "tag": null,
                "type": "ip-netmask",
                "value": "172.168.229.54/32"
            },
            {
                "description": null,
                "name": "172.168.229.72",
                "tag": null,
                "type": "ip-netmask",
                "value": "172.168.229.72"
            },
            {
                "description": "172.168.229.88 ",
                "name": "172.168.229.88",
                "tag": null,
                "type": "ip-netmask",
                "value": "172.168.229.88/32"
            },
            {
                "description": "172.168.229.89 ",
                "name": "172.168.229.89",
                "tag": null,
                "type": "ip-netmask",
                "value": "172.168.229.89/32"
            },
            {
                "description": null,
                "name": "172.168.229.50",
                "tag": null,
                "type": "ip-netmask",
                "value": "172.168.229.50/32"
            }
        ]
    }
}
```

