### PR TITLE
panos_interface: do not add aggregate-group interface on virtual_router

### DIFF
--- a/library/panos_interface.py
+++ b/library/panos_interface.py
@@ -372,13 +372,15 @@ def main():
             changed |= eth.set_vsys(vsys, **reference_params)
             changed |= eth.set_zone(zone_name, mode=eth.mode, **reference_params)
             changed |= eth.set_vlan(vlan_name, **reference_params)
-            changed |= eth.set_virtual_router(vr_name, **reference_params)
+            if 'aggregate-group' not in eth.mode:
+                changed |= eth.set_virtual_router(vr_name, **reference_params)
         except PanDeviceError as e:
             module.fail_json(msg='Failed setref: {0}'.format(e))
     elif state == 'absent':
         # Remove references.
         try:
-            changed |= eth.set_virtual_router(None, **reference_params)
+            if 'aggregate-group' not in eth.mode:
+                changed |= eth.set_virtual_router(None, **reference_params)
             changed |= eth.set_vlan(None, **reference_params)
             changed |= eth.set_zone(None, mode=eth.mode, **reference_params)
             changed |= eth.set_vsys(None, **reference_params)


### PR DESCRIPTION
fix to not add interface to virtual router if it is an aggregate-group assignment

perhaps a few more interface types have to be ignored for virtual router?!?

fixes https://github.com/PaloAltoNetworks/ansible-pan/issues/421