### PR TITLE
Fix panos_commit changed return value.

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -9,6 +9,8 @@ V2.2.4
 * add list of op commands that will not produce changes
 * Add list of type commands that will not produce changes
 * Return output from commands in `panos_type_cmd`
+* Fixed `panos_commit` returning changed as True, even if a commit was not
+  performed.
 
 V2.2.3
 ------

--- a/library/panos_commit.py
+++ b/library/panos_commit.py
@@ -100,6 +100,8 @@ def main():
         required_one_of=helper.required_one_of,
     )
 
+    changed = False
+
     # TODO(gfreeman) - remove in 2.12
     if module.params['devicegroup'] is not None:
         module.deprecate('Param "devicegroup" is deprecated; use "device_group"', '2.12')
@@ -112,13 +114,13 @@ def main():
         module.params['device_group'] = module.params['devicegroup']
 
     helper.get_pandevice_parent(module)
-    helper.commit(
+    changed = helper.commit(
         module,
         include_template=module.params['include_template'],
         admins=module.params['admins'],
     )
 
-    module.exit_json(changed=True)
+    module.exit_json(changed=changed)
 
 
 if __name__ == '__main__':

--- a/module_utils/network/panos/panos.py
+++ b/module_utils/network/panos/panos.py
@@ -426,7 +426,8 @@ class ConnectionHelper(object):
         In the case where the device is Panorama, then a commit-all is
         executed after the commit.  The device group is taken from either
         vsys_dg or device_group.  The template is set to True if template
-        is specified.
+        is specified.  Returns True if the configuration was committed,
+        False if not.
 
         Note:  If module.check_mode is True, then this function does not
         perform the commit.
@@ -436,25 +437,28 @@ class ConnectionHelper(object):
             admins (list): This is the list of admins whose changes will be committed to
                 the firewall/Panorama. The admins argument works with PanOS 8.0+. 
         """
+        committed = False
+
         if module.check_mode:
             return
 
         try:
             self.device.commit(sync=True, exception=True, admins=admins)
+            committed = True
         except PanCommitNotNeeded:
             pass
         except PanDeviceError as e:
             module.fail_json(msg='Failed commit: {0}'.format(e))
 
         if not hasattr(self.device, 'commit_all'):
-            return
+            return committed
 
         dg_name = self.vsys_dg or self.device_group
         if dg_name is not None:
             dg_name = module.params[dg_name]
 
         if dg_name in (None, 'shared'):
-            return
+            return committed
 
         if not include_template:
             if self.template:
@@ -468,10 +472,13 @@ class ConnectionHelper(object):
                 include_template=include_template,
                 exception=True,
             )
+            committed = True
         except PanCommitNotNeeded:
             pass
         except PanDeviceError as e:
             module.fail_json(msg='Failed commit-all: {0}'.format(e))
+
+        return committed
 
     def to_module_dict(self, element, renames=None):
         """Changes a pandevice object or list of objects into a dict / list of dicts.


### PR DESCRIPTION
`panos_commit` was returning `changed = True` regardless of if a commit was performed.  This adds a boolean return value to `commit` in the connection helper which is used by the module.