### PR TITLE
Add new sync_to_peer, download, and install options to panos_software.

### DIFF
--- a/library/panos_software.py
+++ b/library/panos_software.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: panos_software
-short_description: Install specific release of PAN-OS.
+short_description: Manage PAN-OS software versions.
 description:
     - Install specific release of PAN-OS.
 author: "Michael Richardson (@mrichardson03)"
@@ -40,6 +40,20 @@ options:
         description:
             - Desired PAN-OS release for target device.
         required: true
+    sync_to_peer:
+        description:
+            - If device is a member of a HA pair, perform actions on the peer
+              device as well.  Only used when downloading software -
+              installation must be performed on both devices.
+        default: false
+    download:
+        description:
+            - Download PAN-OS version to the device.
+        default: true
+    install:
+        description:
+            - Perform installation of the PAN-OS version on the device.
+        default: true
     restart:
         description:
             - Restart device after installing desired version.  Use in conjunction with
@@ -53,6 +67,21 @@ EXAMPLES = '''
     provider: '{{ provider }}'
     version: '8.1.6'
     restart: true
+
+- name: Download PAN-OS 9.0.0 base image only
+  panos_software:
+    provider: '{{ provider }}'
+    version: '9.0.0'
+    install: false
+    restart: false
+
+- name: Download PAN-OS 9.0.1 and sync to HA peer
+  panos_software:
+    provider: '{{ provider }}'
+    version: '9.0.1'
+    sync_to_peer: true
+    install: false
+    restart: false
 '''
 
 RETURN = '''
@@ -76,6 +105,9 @@ def main():
         with_classic_provider_spec=True,
         argument_spec=dict(
             version=dict(type='str', required=True),
+            sync_to_peer=dict(type='bool', default=False),
+            download=dict(type='bool', default=True),
+            install=dict(type='bool', default=True),
             restart=dict(type='bool', default=False)
         )
     )
@@ -91,6 +123,9 @@ def main():
 
     # Module params.
     version = module.params['version']
+    sync_to_peer = module.params['sync_to_peer']
+    download = module.params['download']
+    install = module.params['install']
     restart = module.params['restart']
 
     changed = False
@@ -101,7 +136,11 @@ def main():
         if PanOSVersion(version) != PanOSVersion(device.version):
 
             if not module.check_mode:
-                device.software.download_install(version, sync=True)
+                if download:
+                    device.software.download(version, sync_to_peer=sync_to_peer, sync=True)
+
+                if install:
+                    device.software.install(version, sync=True)
 
                 if restart:
                     device.restart()


### PR DESCRIPTION
## Description

Added the following options to `panos_software`.  These just expose additional functionality from `pandevice` to the module.

## Motivation and Context

I had large sections of a [HA pair upgrade playbook](https://github.com/mrichardson03/ansible-pan-samples/blob/master/upgrade_ha.yml) that was written using `panos_op` commands to work around this functionality not being implemented in `panos_software`.

## How Has This Been Tested?

Tested on VM-Series using a [modified version](https://github.com/mrichardson03/ansible-pan-samples/blob/module_changes/upgrade_ha.yml) of the same playbook.

## Types of changes

Added boolean arguments to `panos_software`.  Defaults values are set to preserve previous module behavior.

* `sync_to_peer`: If device is a member of a HA pair, perform actions on the peer device as well.  Only used when downloading software - installation must be performed on both devices.
* `download`: Download PAN-OS version to the device.
* `install`: Perform installation of the PAN-OS version on the device.

- New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X ] All new and existing tests passed.
