### PR TITLE
Add 'device_group' param to panos_object_facts doc

### DIFF
--- a/docs/modules/panos_object_facts_module.rst
+++ b/docs/modules/panos_object_facts_module.rst
@@ -56,6 +56,20 @@ Parameters
                                                     <div>The API key to use instead of generating it using <em>username</em> / <em>password</em>.</div>
                                                                                 </td>
             </tr>
+            <tr>
+                                                                <td colspan="2">
+                    <b>device_group</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"shared"</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>(Panorama only) The device group the operation should target.</div>
+                                                                                </td>
+            </tr>
                                 <tr>
                                                                 <td colspan="2">
                     <b>field</b>


### PR DESCRIPTION
The 'device_group' parameter is missing from documentation for the panos_object_facts module

## Description

In panos_object_facts.rst, added table row for the 'device_group' parameter.

## Motivation and Context

Correct documentation for accuracy and consistency.

## How Has This Been Tested?

Documentation change only - no testing

## Screenshots (if appropriate)

n/a

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
