### PR TITLE
Added ability to set the variablesr equired to load a cert

### DIFF
--- a/library/panos_import.py
+++ b/library/panos_import.py
@@ -98,7 +98,7 @@ except ImportError:
 def import_file(xapi, module, ip_address, file_, category, cert_name, cert_pass, cert_type):
     xapi.keygen()
 
-    if category == "certificate":
+    if (category == "certificate" or category == "keypair"):
         params = {
             'type': 'import',
             'category': category,
@@ -235,7 +235,7 @@ def main():
     cert_type = module.params['cert_type']
 
     # Check to ensure proper variables are set
-    if category == "certificate":
+    if (category == "certificate" or category == "keypair"):
         if not cert_name:
             module.fail_json(msg='If the category is certificate, then cert_name is required.')
         if not cert_pass:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The import module lacks the ability to define the variables that would be required to load a certificate to the firewall.

I added the settings required to load a certificate to the firewall, and identified the possible choices for the category that is able to be used as far as I was able to tell.

## Motivation and Context

I could not load a SSL certificate to my firewall, which was kind of a big deal for automated deployments.

## How Has This Been Tested?

I ran through testing in our lab environment, and tested it there.

## Screenshots (if appropriate)

## Types of changes

New code added

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.