### PR TITLE
Add 'device_group' and 'vsys' params to panos_object_facts.py documentation

### DIFF
--- a/library/panos_object_facts.py
+++ b/library/panos_object_facts.py
@@ -70,15 +70,12 @@ options:
         default: 'address'
     vsys:
         description:
-            - The vsys to put the object into.
-            - Firewall only.
+            - The vsys this object belongs to.
         default: "vsys1"
-    devicegroup:
+    device_group:
         description:
-            - The name of the (preexisting) Panorama device group.
-            - If undefined and ip_address is Panorama, this defaults to shared.
-        required: false
-        default: None
+            - (Panorama only) The device group the operation should target.
+        default: "shared"
 '''
 
 EXAMPLES = '''

--- a/library/panos_object_facts.py
+++ b/library/panos_object_facts.py
@@ -68,6 +68,17 @@ options:
             - Type of object to retrieve.
         choices: ['address', 'address-group', 'service', 'service-group', 'tag']
         default: 'address'
+    vsys:
+        description:
+            - The vsys to put the object into.
+            - Firewall only.
+        default: "vsys1"
+    devicegroup:
+        description:
+            - The name of the (preexisting) Panorama device group.
+            - If undefined and ip_address is Panorama, this defaults to shared.
+        required: false
+        default: None
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Originally under PR459. I botched my push.

Adding the 'device_group' and 'vsys' parameters to panos_object_facts.py DOCUMENTATION string. This addresses the changes requested by @shinmog in the original PR.

## Description

Add 'device_group' and 'vsys' parameters to the DOCUMENTATION string in panos_object_facts.py

## Motivation and Context

Correct documentation for accuracy and consistency.

## How Has This Been Tested?

Documentation change only - no testing

## Screenshots (if appropriate)

n/a

## Types of changes

    Bug fix (non-breaking change which fixes an issue)

## Checklist

    [ x] I have updated the documentation accordingly.

I have read the CONTRIBUTING document.
I have added tests to cover my changes if appropriate.
All new and existing tests passed.